### PR TITLE
Houdini and dot-extension support

### DIFF
--- a/lsseq
+++ b/lsseq
@@ -473,7 +473,9 @@ def printSeq(filename, frameList, args, traversedPath) :
         if minFrame == maxFrame :
             fileComponents[1] = (formatStr % minFrame)
         else :
-            fileComponents[1] = "\$F" + str(padding)
+            fileComponents[1] = "\$F"
+            if padding >= 2:
+                fileComponents[1] += str(padding)
         if args.prependPath > 0 and fileComponents[0][0] != '/':
             sys.stdout.write(traversedPath)
         print fileComponents[0] + fileComponents[1] + "." + fileComponents[2]

--- a/lsseq
+++ b/lsseq
@@ -49,14 +49,14 @@ import math
 import time
 from operator import itemgetter
 
-CACHE_EXT = ["ass", "dshd", "fur", "obj", "srf"]
+CACHE_EXT = ["ass", "dshd", "fur", "obj", "srf", "bgeo", "ifd"]
 MOV_EXT = ["avi", "mov", "mp4", "mpg", "wmv"]
 IMAGE_EXT = ["alpha", "als", "anim", "bmp", "btf", "bw", "cin",
     "dib", "dpx", "exr", "gfa", "gif", "giff", "icon", "iff", "img",
     "int", "inta", "jpe", "jpeg", "jpg", "mask", "matte", "pct",
-    "pct1", "pct2", "pdb", "pdd", "pic", "pict", "pix", "png",
-    "psb", "psd", "raw", "rgb", "rgba", "rle", "rw2", "sgi", "tga",
-    "tif", "tiff", "tpic"]
+    "pct1", "pct2", "pdb", "pdd", "pic", "piclc", "picnc", "pict", 
+    "pix", "png", "psb", "psd", "rat", "raw", "rgb", "rgba", "rle", 
+    "rw2", "sgi", "tga", "tif", "tiff", "tpic"]
 
 PATH_UNSPECIFIED = 0
 PATH_ABS = 1
@@ -456,7 +456,7 @@ def printSeq(filename, frameList, args, traversedPath) :
         else :
             sys.stdout.write("")
         print fileComponents[0] + fileComponents[1] + "." + fileComponents[2]
-
+        
     elif args.seqFormat == 'glob' :
         if minFrame < 0 :
             fileComponents[1] = "[\-0-9]"
@@ -465,6 +465,15 @@ def printSeq(filename, frameList, args, traversedPath) :
         if (padding > 1) :
             fileComponents[1] = fileComponents[1] + "[0-9]"*(padding-1)
 
+        if args.prependPath > 0 and fileComponents[0][0] != '/':
+            sys.stdout.write(traversedPath)
+        print fileComponents[0] + fileComponents[1] + "." + fileComponents[2]
+        
+    elif args.seqFormat == 'houdini' :
+        if minFrame == maxFrame :
+            fileComponents[1] = (formatStr % minFrame)
+        else :
+            fileComponents[1] = "\$F" + str(padding)
         if args.prependPath > 0 and fileComponents[0][0] != '/':
             sys.stdout.write(traversedPath)
         print fileComponents[0] + fileComponents[1] + "." + fileComponents[2]
@@ -948,12 +957,12 @@ def main():
         This option implies --prependPathAbs (unless --prependPathRel is \
         explicitly specified) and --onlySequences")
     p.add_argument("--format", "-f", action="store", type=str,
-        choices=("native", "nuke", "rv", "shake", "glob"),
+        choices=("native", "nuke", "rv", "shake", "glob", "houdini"),
         dest="seqFormat",
         metavar="FORMAT",
         default="native",
         help="list image sequences in various formats.\
-        The choices are 'native' (default), 'nuke', 'rv', 'shake' and 'glob'.\
+        The choices are 'native' (default), 'nuke', 'rv', 'shake', 'glob', and 'houdini'.\
         Note that glob prints correct results only if \
         the frame numbers are padded")
     p.add_argument("--goodFrameMinSize", action="store", type=readByteShortForm,

--- a/lsseq
+++ b/lsseq
@@ -49,7 +49,8 @@ import math
 import time
 from operator import itemgetter
 
-CACHE_EXT = ["ass", "dshd", "fur", "obj", "srf", "bgeo", "ifd"]
+CACHE_EXT = ["ass", "dshd", "fur", "obj", "srf", "bgeo", "ifd", "vdb",
+    "bgeo.sc", "bgeo.gz", "ifd.sc", "ifd.gz", "vdb.sc", "vdb.gz"]
 MOV_EXT = ["avi", "mov", "mp4", "mpg", "wmv"]
 IMAGE_EXT = ["alpha", "als", "anim", "bmp", "btf", "bw", "cin",
     "dib", "dpx", "exr", "gfa", "gif", "giff", "icon", "iff", "img",
@@ -228,6 +229,20 @@ def readByteShortForm(bytes) :
         msg = "%r is not a valid byte size" % bytes
         raise argparse.ArgumentTypeError(msg)
 
+def splitFileComponents(filename) :
+    global IMAGE_EXT
+    global CACHE_EXT
+
+    fileComponents = filename.split(".")
+
+    # Check for extensions with dot (for example, blosc compressed bgeos)
+    #
+    if (".".join(fileComponents[-2:]) in IMAGE_EXT) or (".".join(fileComponents[-2:]) in CACHE_EXT) :
+
+        fileComponents[-2] = ".".join(fileComponents[-2:])
+        del fileComponents[-1]
+
+    return fileComponents
 
 # Return two components if "filename" is formatted like a file in a
 # sequence otherwise return an empty list.  The two returned
@@ -241,7 +256,7 @@ def seqSplit(filename, args) :
     global IMAGE_EXT
     global CACHE_EXT
     global LOOSE_SEP
-    fileComponents = filename.split(".")
+    fileComponents = splitFileComponents(filename)
 
     # A file with no extension.
     #
@@ -291,7 +306,7 @@ def isMovie(filename) :
 #
 def splitImageName(filename) :
     numSep = "."
-    fileComponents = filename.split(".")
+    fileComponents = splitFileComponents(filename)
     if fileComponents[-2] == '' :
         fileComponents.pop(-2)
     else :
@@ -469,11 +484,13 @@ def printSeq(filename, frameList, args, traversedPath) :
             sys.stdout.write(traversedPath)
         print fileComponents[0] + fileComponents[1] + "." + fileComponents[2]
         
-    elif args.seqFormat == 'houdini' :
+    elif args.seqFormat == 'houdini' or args.seqFormat == 'mplay':
         if minFrame == maxFrame :
             fileComponents[1] = (formatStr % minFrame)
         else :
-            fileComponents[1] = "\$F"
+            fileComponents[1] = "$F"
+            if args.seqFormat == 'mplay':
+                fileComponents[1] = "\$F"
             if padding >= 2:
                 fileComponents[1] += str(padding)
         if args.prependPath > 0 and fileComponents[0][0] != '/':
@@ -959,12 +976,13 @@ def main():
         This option implies --prependPathAbs (unless --prependPathRel is \
         explicitly specified) and --onlySequences")
     p.add_argument("--format", "-f", action="store", type=str,
-        choices=("native", "nuke", "rv", "shake", "glob", "houdini"),
+        choices=("native", "nuke", "rv", "shake", "glob", "mplay", "houdini"),
         dest="seqFormat",
         metavar="FORMAT",
         default="native",
         help="list image sequences in various formats.\
-        The choices are 'native' (default), 'nuke', 'rv', 'shake', 'glob', and 'houdini'.\
+        The choices are 'native' (default), 'nuke', 'rv', 'shake', 'glob', \
+        'mplay', and 'houdini'.\
         Note that glob prints correct results only if \
         the frame numbers are padded")
     p.add_argument("--goodFrameMinSize", action="store", type=readByteShortForm,
@@ -1083,11 +1101,12 @@ def main():
     tmpExtList.sort();
     IMAGE_EXT = [];
     for e in tmpExtList :
-        if '.' in e :
-            print >> sys.stderr, os.path.basename(sys.argv[0]) + \
-                ": warning: dots are not currently supported in file name extensions so " + e + " is being ignored."
-        else :
-            IMAGE_EXT.append(e);
+        # if '.' in e :
+        #     print >> sys.stderr, os.path.basename(sys.argv[0]) + \
+        #         ": warning: dots are not currently supported in file name extensions so " + e + " is being ignored."
+        # else :
+        #     IMAGE_EXT.append(e);
+        IMAGE_EXT.append(e);
 
     tmpExt = os.getenv("OIC_MOV_EXTENSION")
     if tmpExt != None and tmpExt != "" :
@@ -1111,11 +1130,12 @@ def main():
     tmpExtList.sort();
     CACHE_EXT = []
     for e in tmpExtList :
-        if '.' in e :
-            print >> sys.stderr, os.path.basename(sys.argv[0]) + \
-                ": warning: dots are not currently supported in file name extensions so " + e + " is being ignored."
-        else :
-            CACHE_EXT.append(e);
+        # if '.' in e :
+        #     print >> sys.stderr, os.path.basename(sys.argv[0]) + \
+        #         ": warning: dots are not currently supported in file name extensions so " + e + " is being ignored."
+        # else :
+        #     CACHE_EXT.append(e);
+        CACHE_EXT.append(e)
 
     if args.printImgExtensions :
         extList = ":".join(IMAGE_EXT)

--- a/lsseq
+++ b/lsseq
@@ -1116,11 +1116,12 @@ def main():
     tmpExtList.sort();
     MOV_EXT = []
     for e in tmpExtList :
-        if '.' in e :
-            print >> sys.stderr, os.path.basename(sys.argv[0]) + \
-                ": warning: dots are not currently supported in file name extensions so " + e + " is being ignored."
-        else :
-            MOV_EXT.append(e);
+        # if '.' in e :
+        #     print >> sys.stderr, os.path.basename(sys.argv[0]) + \
+        #         ": warning: dots are not currently supported in movie file name extensions so " + e + " is being ignored."
+        # else :
+        #     MOV_EXT.append(e);
+        MOV_EXT.append(e)
 
     tmpExt = os.getenv("OIC_CACHE_EXTENSION")
     if tmpExt != None and tmpExt != "" :


### PR DESCRIPTION
Thank you for providing lsseq!

I added support for Houdini, and also dot extensions. Houdini uses dot-extended formats a lot, and some are on by default. In it's current form, only extensions with a single dot are supported (i.e. __bgeo.sc__).

There are two new format options: __houdini__ and __mplay__. The only difference is __mplay__ escapes the __$F__so the path will work when opening one or more sequences in mplay from the commandline.

What do you think? So far, it's working for me, and it passes test_lsseq. If you'd like to merge the changes, feel free! Or if there's anything to change or improve, let me know. Hopefully these changes will help Houdini users get more excited about using _lsseq_!

Thanks!